### PR TITLE
Reduce batch size for tier 1 on OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Configure the application by editing `config/config.yaml`. Key settings include:
 To run the pipeline once:
 
 ```
-python main.py
+python3 main.py
 ```
 
 This will:
@@ -84,10 +84,10 @@ This will:
 
 ### Scheduled Operation
 
-To run the pipeline daily at the configured time:
+To run the pipeline daily at the configured time (TODO, Fix scheduler):
 
 ```
-python scheduler/daily_scheduler.py
+python3 scheduler/daily_scheduler.py
 ```
 
 ## 📊 Results

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -19,7 +19,7 @@ subreddits:
 # Reddit scraping settings
 scraper:
   min_post_age_days: 5              # Post must be at least 5 days old
-  max_post_age_days: 7             # Ignore posts older than 3 months
+  max_post_age_days: 30             # Ignore posts older than 3 months
   max_items_per_day: 300            # Total posts/comments scraped per run
   include_comments: true
   rate_limit_per_minute: 60         # Reddit API rate limit

--- a/scheduler/runner.py
+++ b/scheduler/runner.py
@@ -23,7 +23,7 @@ log = setup_logger()
 config = get_config()
 
 
-def split_batch_by_token_limit(payload, model: str, token_limit: int = 200_000):
+def split_batch_by_token_limit(payload, model: str, token_limit: int = 100_000):
     batches = []
     current_batch = []
     current_tokens = 0


### PR DESCRIPTION
- Reduced batch size to avoid failure batches for tier 1 on OpenAI
- Configured to get last 30 days of posts
- Improved Readme file